### PR TITLE
Add mingw support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Binaries/
 Objects/
 .vs/
+*.o

--- a/BSR/Headers/Dependencies.hpp
+++ b/BSR/Headers/Dependencies.hpp
@@ -10,12 +10,12 @@
 
 #pragma pack(pop)
 
-
-
+#ifndef __MINGW32__
 #include "WinTargetVer.hpp"
 #include <Windows.h>
-
-
+#else
+#include <windows.h>
+#endif
 
 #include <iostream>
 #include <fstream>

--- a/BSR/Makefile
+++ b/BSR/Makefile
@@ -1,0 +1,43 @@
+IDIR=Headers
+SDIR=Sources
+CXX=x86_64-w64-mingw32-g++
+
+CFLAGS+=-I$(IDIR) -I/usr/x86_64-w64-mingw32/include -std=c++23
+
+LDIR=""
+ODIR=Build
+
+LIBS=-lm -municode
+
+SIMPLE_DEPS = AssetManager.hpp Macros.hpp\
+Renderer.hpp Templates.hpp\
+WinTargetVer.hpp BSR.hpp\
+Math.hpp Resources.hpp\
+Time.hpp Dependencies.hpp\
+MultiProcessing.hpp RunTime.hpp\
+Vector.hpp Image.hpp\
+Rasterizer.hpp String.hpp\
+Window.hpp
+
+DEPS = $(patsubst %,$(IDIR)/%,$(SIMPLE_DEPS))
+
+SIMPLE_OBJ = AssetManager.o Math_Vector.o\
+Renderer.o Time.o\
+Image.o MultiProcessing.o\
+Renderer_Instance.o Window.o\
+Math.o Rasterizer.o\
+RunTime.o Math_Matrix.o\
+Rasterizer_Texture.o  String.o
+OBJ = $(patsubst %,$(ODIR)/%,$(SIMPLE_OBJ))
+
+bsr.a: $(OBJ)
+	ar rcs $@ $^
+
+$(ODIR)/%.o: $(SDIR)/%.cpp $(DEPS)
+	mkdir -p $(ODIR)
+	$(CXX) -c -o $@ $< $(CFLAGS)
+
+.PHONY: clean
+
+clean:
+	rm -f $(ODIR)/*.o *~ core $(INCDIR)/*~ 

--- a/BSR/Sources/AssetManager.cpp
+++ b/BSR/Sources/AssetManager.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Image.cpp
+++ b/BSR/Sources/Image.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 
@@ -712,7 +712,7 @@ uint8_t* BSR::Image::LoadBmp(const wchar_t* _Path, size_t& _Width, size_t& _Heig
 		return nullptr;
 	}
 
-	HBITMAP _hBmp = (HBITMAP)(LoadImage(NULL, _Path, IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE));
+	HBITMAP _hBmp = (HBITMAP)(LoadImageW(NULL, _Path, IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE));
 
 	if (!_hBmp)
 	{

--- a/BSR/Sources/Math.cpp
+++ b/BSR/Sources/Math.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Math_Matrix.cpp
+++ b/BSR/Sources/Math_Matrix.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Math_Vector.cpp
+++ b/BSR/Sources/Math_Vector.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/MultiProcessing.cpp
+++ b/BSR/Sources/MultiProcessing.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 
@@ -28,7 +28,7 @@ bool BSR::MultiProcessing::SharedMemory::Create(const wchar_t* _Name, const size
 		return false;
 	}
 
-	Handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, (uint32_t)(_Size), _Name);
+	Handle = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, (uint32_t)(_Size), _Name);
 
 	if (!Handle)
 	{
@@ -133,7 +133,7 @@ bool BSR::MultiProcessing::SharedMutex::Create(const wchar_t* _Name)
 {
 	Destroy();
 
-	Handle = CreateMutex(NULL, FALSE, _Name);
+	Handle = CreateMutexW(NULL, FALSE, _Name);
 
 	if (!Handle)
 	{
@@ -219,16 +219,16 @@ bool BSR::MultiProcessing::Process::Create(const wchar_t* _Path, const wchar_t* 
 		return false;
 	}
 
-	SHELLEXECUTEINFO _ShellExecInfo = { 0 };
+	SHELLEXECUTEINFOW _ShellExecInfo = { 0 };
 
-	_ShellExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+	_ShellExecInfo.cbSize = sizeof(SHELLEXECUTEINFOW);
 	_ShellExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
 	_ShellExecInfo.lpFile = _Path;
 	_ShellExecInfo.lpParameters = _CmdLine;
 	_ShellExecInfo.lpDirectory = _WorkingDir;
 	_ShellExecInfo.nShow = _ShowCmd;
 
-	if (!ShellExecuteEx(&_ShellExecInfo))
+	if (!ShellExecuteExW(&_ShellExecInfo))
 	{
 		return false;
 	}
@@ -252,9 +252,9 @@ bool BSR::MultiProcessing::Process::CreateElevated(const wchar_t* _Path, const w
 		return false;
 	}
 
-	SHELLEXECUTEINFO _ShellExecInfo = { 0 };
+	SHELLEXECUTEINFOW _ShellExecInfo = { 0 };
 
-	_ShellExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+	_ShellExecInfo.cbSize = sizeof(SHELLEXECUTEINFOW);
 	_ShellExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
 	_ShellExecInfo.lpVerb = L"runas";
 	_ShellExecInfo.lpFile = _Path;
@@ -262,7 +262,7 @@ bool BSR::MultiProcessing::Process::CreateElevated(const wchar_t* _Path, const w
 	_ShellExecInfo.lpDirectory = _WorkingDir;
 	_ShellExecInfo.nShow = _ShowCmd;
 
-	if (!ShellExecuteEx(&_ShellExecInfo))
+	if (!ShellExecuteExW(&_ShellExecInfo))
 	{
 		return false;
 	}

--- a/BSR/Sources/Rasterizer.cpp
+++ b/BSR/Sources/Rasterizer.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 
@@ -826,11 +826,11 @@ const bool BSR::Rasterizer::Context::RenderMesh(const void* _VBO, const size_t _
 
 			bool _FrontFacing = BSR::Math::Vec3f::Cross(_ScreenB - _ScreenA, _ScreenC - _ScreenA).z > 0.0f;
 
-			size_t _StartX = (size_t)(BSR::Math::Clamp(std::floorf(BSR::Math::Min(BSR::Math::Min((_ScreenA.x + 1.0f) / 2.0f, (_ScreenB.x + 1.0f) / 2.0f), (_ScreenC.x + 1.0f) / 2.0f) * (float)(ViewPortWidth)), 0.0f, (float)(ViewPortWidth)));
-			size_t _StartY = (size_t)(BSR::Math::Clamp(std::floorf(BSR::Math::Min(BSR::Math::Min((_ScreenA.y + 1.0f) / 2.0f, (_ScreenB.y + 1.0f) / 2.0f), (_ScreenC.y + 1.0f) / 2.0f) * (float)(ViewPortHeight)), 0.0f, (float)(ViewPortHeight)));
+			size_t _StartX = (size_t)(BSR::Math::Clamp(floorf(BSR::Math::Min(BSR::Math::Min((_ScreenA.x + 1.0f) / 2.0f, (_ScreenB.x + 1.0f) / 2.0f), (_ScreenC.x + 1.0f) / 2.0f) * (float)(ViewPortWidth)), 0.0f, (float)(ViewPortWidth)));
+			size_t _StartY = (size_t)(BSR::Math::Clamp(floorf(BSR::Math::Min(BSR::Math::Min((_ScreenA.y + 1.0f) / 2.0f, (_ScreenB.y + 1.0f) / 2.0f), (_ScreenC.y + 1.0f) / 2.0f) * (float)(ViewPortHeight)), 0.0f, (float)(ViewPortHeight)));
 
-			size_t _EndX = (size_t)(BSR::Math::Clamp(std::ceilf(BSR::Math::Max(BSR::Math::Max((_ScreenA.x + 1.0f) / 2.0f, (_ScreenB.x + 1.0f) / 2.0f), (_ScreenC.x + 1.0f) / 2.0f) * (float)(ViewPortWidth)), 0.0f, (float)(ViewPortWidth)));
-			size_t _EndY = (size_t)(BSR::Math::Clamp(std::ceilf(BSR::Math::Max(BSR::Math::Max((_ScreenA.y + 1.0f) / 2.0f, (_ScreenB.y + 1.0f) / 2.0f), (_ScreenC.y + 1.0f) / 2.0f) * (float)(ViewPortHeight)), 0.0f, (float)(ViewPortHeight)));
+			size_t _EndX = (size_t)(BSR::Math::Clamp(ceilf(BSR::Math::Max(BSR::Math::Max((_ScreenA.x + 1.0f) / 2.0f, (_ScreenB.x + 1.0f) / 2.0f), (_ScreenC.x + 1.0f) / 2.0f) * (float)(ViewPortWidth)), 0.0f, (float)(ViewPortWidth)));
+			size_t _EndY = (size_t)(BSR::Math::Clamp(ceilf(BSR::Math::Max(BSR::Math::Max((_ScreenA.y + 1.0f) / 2.0f, (_ScreenB.y + 1.0f) / 2.0f), (_ScreenC.y + 1.0f) / 2.0f) * (float)(ViewPortHeight)), 0.0f, (float)(ViewPortHeight)));
 
 			for (size_t _Y = ViewPortY + _StartY; _Y < ViewPortY + _EndY; _Y++)
 			{

--- a/BSR/Sources/Rasterizer_Texture.cpp
+++ b/BSR/Sources/Rasterizer_Texture.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Renderer.cpp
+++ b/BSR/Sources/Renderer.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Renderer_Instance.cpp
+++ b/BSR/Sources/Renderer_Instance.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/RunTime.cpp
+++ b/BSR/Sources/RunTime.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/String.cpp
+++ b/BSR/Sources/String.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Time.cpp
+++ b/BSR/Sources/Time.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 

--- a/BSR/Sources/Window.cpp
+++ b/BSR/Sources/Window.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR.hpp"
+#include "../Headers/BSR.hpp"
 
 
 
@@ -240,7 +240,7 @@ void BSR::Window::WndThreadFunc(bool* _Done, bool* _Fail, Window* _Wnd, const Wi
 
 	LastWnd = _Wnd;
 
-	_Wnd->Handle = CreateWindowEx(_Descriptor->dwExStyle, _Descriptor->lpClassName, _Descriptor->lpWindowName, _Descriptor->dwStyle, _Descriptor->X, _Descriptor->Y, _Descriptor->nWidth, _Descriptor->nHeight, _Descriptor->HandleParent, _Descriptor->hMenu, _Descriptor->hInstance, _Descriptor->lpParam);
+	_Wnd->Handle = CreateWindowExW(_Descriptor->dwExStyle, _Descriptor->lpClassName, _Descriptor->lpWindowName, _Descriptor->dwStyle, _Descriptor->X, _Descriptor->Y, _Descriptor->nWidth, _Descriptor->nHeight, _Descriptor->HandleParent, _Descriptor->hMenu, _Descriptor->hInstance, _Descriptor->lpParam);
 
 	LastWnd = nullptr;
 

--- a/BSR_APP/Headers/Application.hpp
+++ b/BSR_APP/Headers/Application.hpp
@@ -4,7 +4,7 @@
 
 
 
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 

--- a/BSR_APP/Headers/MainMenu.hpp
+++ b/BSR_APP/Headers/MainMenu.hpp
@@ -4,7 +4,7 @@
 
 
 
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 

--- a/BSR_APP/Makefile
+++ b/BSR_APP/Makefile
@@ -1,0 +1,33 @@
+BSR_LIBRARY_IDIR=../BSR/Headers
+IDIR=Headers
+SDIR=Sources
+CXX=x86_64-w64-mingw32-g++
+
+CFLAGS+=-I$(IDIR) -I$(BSR_LIBRARY_IDIR) -I/usr/x86_64-w64-mingw32/include -std=c++23
+
+LDIR=../BSR
+ODIR=Build
+
+LIBS=-static -lm -L$(LDIR) -l:bsr.a -municode -lole32 -lgdi32 -lwinmm
+
+SIMPLE_DEPS = Application.hpp Dependencies.hpp \
+MainMenu.hpp Templates.hpp \
+BSR_APP.hpp Macros.hpp \
+Resources.hpp Window.hpp
+
+DEPS = $(patsubst %,$(IDIR)/%,$(SIMPLE_DEPS))
+
+SIMPLE_OBJ = Application.o EntryPoint.o MainMenu.o Window.o
+OBJ = $(patsubst %,$(ODIR)/%,$(SIMPLE_OBJ))
+
+BSR_APP: $(OBJ)
+	$(CXX) -o $@ $^ $(CFLAGS) $(LIBS)
+
+$(ODIR)/%.o: $(SDIR)/%.cpp $(DEPS)
+	mkdir -p $(ODIR)
+	$(CXX) -c -o $@ $< $(CFLAGS)
+
+.PHONY: clean
+
+clean:
+	rm -f $(ODIR)/*.o *~ core $(INCDIR)/*~ 

--- a/BSR_APP/Sources/Application.cpp
+++ b/BSR_APP/Sources/Application.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 
@@ -73,7 +73,7 @@ void BSR_APP::RunTime::Application::UpdateFullScreen()
 
 		_MonitorInfo.cbSize = sizeof(MONITORINFOEX);
 
-		GetMonitorInfo(_hMonitor, &_MonitorInfo);
+		GetMonitorInfo(_hMonitor, (LPMONITORINFO)&_MonitorInfo);
 
 		SetWindowLongPtr(MainWindow, GWL_STYLE, WS_POPUP);
 
@@ -129,7 +129,7 @@ bool BSR_APP::RunTime::Application::InitInstance()
 
 	if (_InstanceCount != 1)
 	{
-		HWND _hWnd = FindWindow(L"BSR_APP_MainWindow", L"BSR_APP");
+		HWND _hWnd = FindWindowW(L"BSR_APP_MainWindow", L"BSR_APP");
 
 		if (_hWnd)
 		{
@@ -144,7 +144,7 @@ bool BSR_APP::RunTime::Application::InitInstance()
 
 bool BSR_APP::RunTime::Application::InitMainWindow()
 {
-	WNDCLASSEX _WndClass = { 0 };
+	WNDCLASSEXW _WndClass = { 0 };
 
 	_WndClass.cbSize = sizeof(WNDCLASSEX);
 	_WndClass.style = CS_OWNDC | CS_VREDRAW | CS_HREDRAW;
@@ -159,7 +159,7 @@ bool BSR_APP::RunTime::Application::InitMainWindow()
 	_WndClass.lpszClassName = L"BSR_APP_MainWindow";
 	_WndClass.hIconSm = LoadIcon(GetInstanceHandle(), MAKEINTRESOURCE(BSR_APP_IDI_MAIN_ICON));
 
-	if (!RegisterClassEx(&_WndClass))
+	if (!RegisterClassExW(&_WndClass))
 	{
 		return false;
 	}
@@ -179,7 +179,7 @@ bool BSR_APP::RunTime::Application::InitMainWindow()
 	if (!MainWindowData.Image.Data)
 	{
 		MainWindowData = WindowData();
-		UnregisterClass(_WndClass.lpszClassName, _WndClass.hInstance);
+		UnregisterClassW(_WndClass.lpszClassName, _WndClass.hInstance);
 		return false;
 	}
 
@@ -189,7 +189,7 @@ bool BSR_APP::RunTime::Application::InitMainWindow()
 	{
 		delete[] MainWindowData.Image.Data;
 		MainWindowData = WindowData();
-		UnregisterClass(_WndClass.lpszClassName, _WndClass.hInstance);
+		UnregisterClassW(_WndClass.lpszClassName, _WndClass.hInstance);
 		return false;
 	}
 
@@ -225,7 +225,7 @@ bool BSR_APP::RunTime::Application::InitMainWindow()
 		delete[] MainWindowData.Depth;
 		delete[] MainWindowData.Image.Data;
 		MainWindowData = WindowData();
-		UnregisterClass(_WndClass.lpszClassName, _WndClass.hInstance);
+		UnregisterClassW(_WndClass.lpszClassName, _WndClass.hInstance);
 		return false;
 	}
 
@@ -245,7 +245,7 @@ void BSR_APP::RunTime::Application::CleanUpMainWindow()
 	delete[] MainWindowData.Depth;
 	delete[] MainWindowData.Image.Data;
 	MainWindowData = WindowData();
-	UnregisterClass(L"BSR_APP_MainWindow", GetInstanceHandle());
+	UnregisterClassW(L"BSR_APP_MainWindow", GetInstanceHandle());
 }
 
 bool BSR_APP::RunTime::Application::LoadModel(const wchar_t* _Path, const wchar_t* _AssetName)

--- a/BSR_APP/Sources/EntryPoint.cpp
+++ b/BSR_APP/Sources/EntryPoint.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 
@@ -6,13 +6,13 @@ int WINAPI wWinMain(_In_ HINSTANCE _hInstance, _In_opt_ HINSTANCE _hPrevInstance
 {
 	if (CoInitializeEx(nullptr, COINIT::COINIT_MULTITHREADED) != S_OK)
 	{
-		MessageBox(NULL, BSR_STRING_TYPE("An unexpected error occurred."), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
+		MessageBox(NULL, BSR_STRING_TYPE("Couldn't initialize multithreading!"), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
 		return BSR::MultiProcessing::_ReturnError;
 	}
 
 	if (!BSR::Time::Init())
 	{
-		MessageBox(NULL, BSR_STRING_TYPE("An unexpected error occurred."), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
+		MessageBox(NULL, BSR_STRING_TYPE("Couldn't initialize timer!"), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
 		CoUninitialize();
 		return BSR::MultiProcessing::_ReturnError;
 	}
@@ -23,7 +23,7 @@ int WINAPI wWinMain(_In_ HINSTANCE _hInstance, _In_opt_ HINSTANCE _hPrevInstance
 
 	if (_ReturnValue != BSR::MultiProcessing::_ReturnNoError)
 	{
-		MessageBox(NULL, BSR_STRING_TYPE("An unexpected error occurred."), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
+		MessageBox(NULL, BSR_STRING_TYPE("BSR returned error!"), BSR_STRING_TYPE("Error!"), MB_OK | MB_ICONERROR);
 	}
 
 	BSR::Time::Stop();

--- a/BSR_APP/Sources/MainMenu.cpp
+++ b/BSR_APP/Sources/MainMenu.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 
@@ -413,7 +413,7 @@ void BSR_APP::RunTime::MainMenu::RenderAndSave()
 	delete[] _FrameBuffer.Stencil;
 	delete[] _FrameBuffer.Result;
 
-	ShellExecute(_ApplicationObj->GetMainWindow(), nullptr, L".\\Result.bmp", nullptr, nullptr, SW_SHOW);
+	ShellExecuteW(_ApplicationObj->GetMainWindow(), nullptr, L".\\Result.bmp", nullptr, nullptr, SW_SHOW);
 }
 
 void BSR_APP::RunTime::MainMenu::Render()

--- a/BSR_APP/Sources/Window.cpp
+++ b/BSR_APP/Sources/Window.cpp
@@ -1,4 +1,4 @@
-#include "..\Headers\BSR_APP.hpp"
+#include "../Headers/BSR_APP.hpp"
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all:
+	$(MAKE) -C BSR 
+	$(MAKE) -C BSR_APP 
+
+debug:
+	CFLAGS='-D _DEBUG' $(MAKE) -C BSR 
+	CFLAGS='-D _DEBUG' $(MAKE) -C BSR_APP 
+
+clean:
+	$(MAKE) -C BSR clean
+	$(MAKE) -C BSR_APP clean
+
+.PHONY: all debug clean


### PR DESCRIPTION
Adds makefiles for cross compiling with the mingw cross compiler on linux, this allows BSR to be compiled on linux, of course since mingw is a cross compiler the result is still a .exe so to run the compiled app you need wine, but as convoluted as this workflow is, at least BSR can now be developed on linux too.

To test this simply install the `mingw-w64` package on linux, clone the repo and run: `make` or `make -j$(nproc)` (for multi threaded compilation) in the root of the repo. This will compile BSR and BSR_APP, the result will be a BSR_APP.exe in the BSR_APP folder, which can then be ran by installing `wine` and doing: `wine BSR_APP.exe`.